### PR TITLE
Add Claude session start hook to auto-install dependencies

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in Claude Code on the web (remote) sessions
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Installs dependencies; the "prepare" script also runs the TypeScript build
+pnpm install

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-# Only run in Claude Code on the web (remote) sessions
 if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
 cd "$CLAUDE_PROJECT_DIR"
 
-# Installs dependencies; the "prepare" script also runs the TypeScript build
 pnpm install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Claude IDE integration configuration to automatically install project dependencies when a remote coding session starts.

## Key Changes
- Added `.claude/settings.json` configuration file that defines a `SessionStart` hook
- Added `.claude/hooks/session-start.sh` bash script that runs `pnpm install` when a remote session begins
- The hook only executes in remote coding environments (checks `CLAUDE_CODE_REMOTE` environment variable)

## Implementation Details
- The session start hook is configured to execute a bash script located at `.claude/hooks/session-start.sh`
- The script includes safety flags (`set -euo pipefail`) for robust error handling
- The script gracefully exits early if not running in a remote environment, preventing unnecessary execution in local development
- Uses `pnpm install` to ensure dependencies are available at the start of each remote coding session

https://claude.ai/code/session_016LFwFMTCCDv6b2BBNPucqH