### PR TITLE
Add BSD 3-Clause license and update package metadata

### DIFF
--- a/.changeset/license-bsd-3-clause.md
+++ b/.changeset/license-bsd-3-clause.md
@@ -1,7 +1,0 @@
----
-"effect-units": patch
----
-
-License the package under BSD 3-Clause, retaining the copyright notice of
-`ianmackenzie/elm-units` (the BSD-3-Clause-licensed library effect-units is
-ported from) as that license requires.

--- a/.changeset/license-bsd-3-clause.md
+++ b/.changeset/license-bsd-3-clause.md
@@ -1,0 +1,7 @@
+---
+"effect-units": patch
+---
+
+License the package under BSD 3-Clause, retaining the copyright notice of
+`ianmackenzie/elm-units` (the BSD-3-Clause-licensed library effect-units is
+ported from) as that license requires.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+BSD 3-Clause License
+
+Copyright (c) 2026, RJ Dellecese
+Copyright (c) 2018, Ian Mackenzie
+
+effect-units is a port of elm-units
+(https://github.com/ianmackenzie/elm-units), copyright Ian Mackenzie, which
+is also licensed under the BSD 3-Clause License. Ian Mackenzie's copyright
+notice, these conditions, and the disclaimer below are retained from
+elm-units as that license requires.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from this
+   software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -115,3 +115,10 @@ pnpm install
 pnpm test
 pnpm build
 ```
+
+## License
+
+[BSD 3-Clause](./LICENSE). effect-units derives from
+[`ianmackenzie/elm-units`](https://github.com/ianmackenzie/elm-units)
+(copyright Ian Mackenzie, also BSD 3-Clause); its copyright notice is
+retained in [LICENSE](./LICENSE).

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "default": "./dist/*.js"
     }
   },
-  "license": "UNLICENSED",
+  "license": "BSD-3-Clause",
   "packageManager": "pnpm@11.10.0",
   "peerDependencies": {
     "effect": "^3.21.4"


### PR DESCRIPTION
Adds licensing information to the project and updates package metadata to reflect the project's legal status.

## Changes

- **LICENSE**: Added BSD 3-Clause license file, including copyright notices for both the current project (RJ Dellecese, 2026) and the original elm-units project (Ian Mackenzie, 2018) that this library is ported from
- **package.json**: Updated `license` field from `"UNLICENSED"` to `"BSD-3-Clause"` to accurately reflect the project's licensing
- **README.md**: Added "License" section documenting the BSD 3-Clause license and acknowledging the derivation from `ianmackenzie/elm-units`

## Details

effect-units is a port of the elm-units library. The BSD 3-Clause license properly attributes the original work while allowing the derivative project to be used under the same permissive terms. The license file retains Ian Mackenzie's copyright notice as required by the license itself.

https://claude.ai/code/session_01UYhhqZwP17oxigepmt1jiZ