### PR TITLE
Remove elm-units attribution from LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,12 +3,6 @@ BSD 3-Clause License
 Copyright (c) 2026, RJ Dellecese
 Copyright (c) 2018, Ian Mackenzie
 
-effect-units is a port of elm-units
-(https://github.com/ianmackenzie/elm-units), copyright Ian Mackenzie, which
-is also licensed under the BSD 3-Clause License. Ian Mackenzie's copyright
-notice, these conditions, and the disclaimer below are retained from
-elm-units as that license requires.
-
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Removes the attribution paragraph referencing elm-units from the BSD 3-Clause License file.

This change simplifies the LICENSE by removing the notice that effect-units is a port of elm-units and the associated copyright/license retention statement that was previously required by elm-units' BSD 3-Clause License terms.

https://claude.ai/code/session_013Azo2fo2JZzhHeQZvoentB