### PR TITLE
Prepare package for initial npm release

### DIFF
--- a/.changeset/cool-hoops-play.md
+++ b/.changeset/cool-hoops-play.md
@@ -1,0 +1,5 @@
+---
+"effect-units": minor
+---
+
+Initial release.

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,12 +1,6 @@
 name: "Setup"
 description: "Sets up Node.js and pnpm and installs dependencies"
 
-inputs:
-  registry-url:
-    description: "Optional npm registry to configure for publishing"
-    required: false
-    default: ""
-
 runs:
   using: "composite"
   steps:
@@ -18,7 +12,6 @@ runs:
       with:
         node-version-file: ".node-version"
         cache: "pnpm"
-        registry-url: ${{ inputs.registry-url }}
 
     - name: Install dependencies
       run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,9 @@
+# Publishes to npm with trusted publishing (OIDC): `pnpm publish` exchanges the
+# workflow's OIDC token for a short-lived registry token, so there is no npm
+# token anywhere in this repo. npm's trusted publisher config for the package
+# pins this file's name, so renaming it breaks publishing. `id-token: write`
+# below is what lets the runner mint the OIDC token; provenance attestations
+# come along automatically with it.
 name: Release
 
 on:
@@ -20,8 +26,6 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: ./.github/actions/setup
-        with:
-          registry-url: "https://registry.npmjs.org"
 
       - name: Create release pull request or publish
         uses: changesets/action@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,4 +24,8 @@ The package is built with tsdown (JavaScript output; `dts: false` delegates decl
 
 ## Versioning and Publishing
 
-Versioning and changelogs are managed with Changesets. Use `pnpm changeset` to create a changeset before merging a PR with user-facing changes; the Release workflow opens/updates a "Version Packages" PR and tags releases when it merges. The package is currently `private`, so `changeset publish` tags releases without publishing to npm.
+Versioning and changelogs are managed with Changesets. Use `pnpm changeset` to create a changeset before merging a PR with user-facing changes; the Release workflow opens/updates a "Version Packages" PR, and merging that PR publishes to npm, tags the release, and creates the GitHub release.
+
+Publishing uses npm trusted publishing (OIDC): `.github/workflows/release.yml` requests an `id-token` and `pnpm publish` exchanges it for a short-lived registry token, so there is no npm token in the repo or in Actions secrets. npm's trusted publisher config for the package pins the workflow filename, so `release.yml` cannot be renamed without updating it at https://www.npmjs.com/package/effect-units/access. Provenance attestations are generated automatically as part of trusted publishing.
+
+The published tarball is the `files` allowlist in `package.json` (`dist` plus `src`, so declaration maps resolve to sources) with `LICENSE`, `README.md`, and `package.json`. `dist` is gitignored but still ships, because `files` takes precedence. Verify a change to packaging with `CI=1 pnpm pack`.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "effect-units",
   "description": "Typed quantities and unit conversions for Effect",
   "version": "0.0.0",
+  "author": "RJ Dellecese <rj@rjdellecese.com>",
+  "bugs": {
+    "url": "https://github.com/rjdellecese/effect-units/issues"
+  },
   "devDependencies": {
     "@changesets/cli": "2.31.0",
     "@changesets/config": "3.1.4",
@@ -22,18 +26,36 @@
     "node": ">=22"
   },
   "exports": {
+    "./package.json": "./package.json",
     "./*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
       "default": "./dist/*.js"
     }
   },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "homepage": "https://github.com/rjdellecese/effect-units#readme",
+  "keywords": [
+    "dimensional-analysis",
+    "effect",
+    "elm-units",
+    "measurement",
+    "quantities",
+    "typescript",
+    "unit-conversion",
+    "units"
+  ],
   "license": "BSD-3-Clause",
   "packageManager": "pnpm@11.10.0",
   "peerDependencies": {
     "effect": "^3.21.4"
   },
-  "private": true,
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rjdellecese/effect-units.git"


### PR DESCRIPTION
Configures the package for public npm publishing and updates documentation to reflect the new publishing workflow.

## Changes

- **package.json**: Converted from private to public package
  - Removed `"private": true`
  - Added `"publishConfig": { "access": "public" }` for explicit public access
  - Added package metadata: `author`, `bugs`, `homepage`, `keywords`
  - Added `"files"` allowlist to control tarball contents (`dist` and `src`)
  - Added `"./package.json"` to exports for better tooling support

- **.github/workflows/release.yml**: Migrated to npm trusted publishing (OIDC)
  - Removed `registry-url` input from setup action call
  - Added detailed comments explaining OIDC token exchange and provenance attestations
  - Workflow now publishes directly via `pnpm publish` without stored npm tokens

- **.github/actions/setup/action.yml**: Removed npm registry configuration
  - Deleted `registry-url` input (no longer needed with OIDC)
  - Removed `registry-url` parameter from Node.js setup step

- **CLAUDE.md**: Updated publishing documentation
  - Clarified that Release workflow now publishes to npm (not just tags)
  - Documented npm trusted publishing (OIDC) setup and security model
  - Explained `files` allowlist behavior and how to verify packaging changes

- **.changeset/cool-hoops-play.md**: Added initial release changeset

## Implementation Details

Publishing now uses npm's trusted publishing feature: the workflow requests an `id-token`, and `pnpm publish` exchanges it for a short-lived registry token. This eliminates the need for stored npm credentials. The workflow filename (`release.yml`) is pinned in npm's trusted publisher config and cannot be renamed without updating that configuration.

The published tarball includes `dist/` (built output), `src/` (for declaration map source resolution), plus `LICENSE`, `README.md`, and `package.json`. The `dist/` directory is gitignored but included via the `files` allowlist.

https://claude.ai/code/session_01Gv66ewYRGVJDkrzu253wGf