### PR TITLE
Preserve concrete unit types in Quantity.sum reducer callbacks

### DIFF
--- a/.changeset/fuzzy-pandas-add.md
+++ b/.changeset/fuzzy-pandas-add.md
@@ -1,0 +1,5 @@
+---
+"effect-units": patch
+---
+
+Preserve concrete unit types when `Quantity.sum` is passed directly to reducer callbacks.

--- a/src/Quantity.ts
+++ b/src/Quantity.ts
@@ -160,8 +160,10 @@ export const divide: {
 );
 
 export const sum: {
-  <U extends Unit.Unit>(b: Quantity<U>): (a: Quantity<U>) => Quantity<U>;
   <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<U>): Quantity<U>;
+  <Q>(
+    b: Q & { readonly [TypeId]: TypeId },
+  ): [Q] extends [Quantity<infer U>] ? (a: Quantity<U>) => Quantity<U> : never;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>

--- a/test/CustomUnits.test.ts
+++ b/test/CustomUnits.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest";
+import { describe, expectTypeOf, it } from "@effect/vitest";
 import {
   assertEquals,
   assertFalse,
@@ -6,6 +6,7 @@ import {
   deepStrictEqual,
   throws,
 } from "@effect/vitest/utils";
+import * as Array from "effect/Array";
 import * as Either from "effect/Either";
 import * as Equal from "effect/Equal";
 import * as Schema from "effect/Schema";
@@ -113,6 +114,24 @@ describe("custom units (a consumer-authored USD module)", () => {
     );
 
     assertTrue(isCloseTo(Length.inMeters(affordable), 10));
+  });
+
+  it("preserves a rate unit when sum is passed to Array.reduce", () => {
+    type Count = Unit.Custom<"Count">;
+    const Count: Count = Unit.custom("Count");
+    type UsdPerCount = Quantity.Quantity<Unit.Rate<Usd, Count>>;
+    const UsdPerCount = Unit.rate(Usd, Count);
+    const rates: Array<UsdPerCount> = [
+      Quantity.make(UsdPerCount, 2),
+      Quantity.make(UsdPerCount, 3),
+    ];
+    const zero: UsdPerCount = Quantity.make(UsdPerCount, 0);
+
+    const total = Array.reduce(rates, zero, Quantity.sum);
+
+    expectTypeOf(total).toEqualTypeOf<UsdPerCount>();
+    assertEquals(total.value, 5);
+    assertTrue(Unit.equals(total.unit, UsdPerCount));
   });
 
   it("roundtrips through the schema, freezing the wire format", () => {


### PR DESCRIPTION
## Summary

- Preserve concrete quantity unit types when `Quantity.sum` is passed directly to reducer callbacks.
- Add a regression test covering custom rate units with `Array.reduce`.
- Include a patch changeset for the type-level fix.

## Testing

- Added type-level and runtime assertions for summed custom rate quantities.