### PR TITLE
Fix point-free quantity reducer inference

### DIFF
--- a/.changeset/clever-rates-add.md
+++ b/.changeset/clever-rates-add.md
@@ -2,4 +2,4 @@
 "effect-units": patch
 ---
 
-Preserve concrete units when using compatible quantity operations point-free, including as `Array.reduce` callbacks.
+Preserve concrete units when using compatible quantity operations in a point-free style.

--- a/.changeset/clever-rates-add.md
+++ b/.changeset/clever-rates-add.md
@@ -2,4 +2,4 @@
 "effect-units": patch
 ---
 
-Preserve concrete units when passing compatible quantity operations directly to `Array.reduce`.
+Preserve concrete units when using compatible quantity operations point-free, including as `Array.reduce` callbacks.

--- a/.changeset/clever-rates-add.md
+++ b/.changeset/clever-rates-add.md
@@ -1,0 +1,5 @@
+---
+"effect-units": patch
+---
+
+Preserve concrete units when passing compatible quantity operations directly to `Array.reduce`.

--- a/src/Quantity.ts
+++ b/src/Quantity.ts
@@ -80,6 +80,9 @@ export interface Quantity<U extends Unit.Unit>
   readonly value: number;
 }
 
+type QuantityUnit<Q> = [Q] extends [Quantity<infer U>] ? U : never;
+type QuantityInput<Q> = Q & Quantity<Unit.Unit>;
+
 const isQuantity = (u: unknown): u is Quantity<Unit.Unit> =>
   Predicate.hasProperty(u, TypeId);
 
@@ -176,6 +179,7 @@ export const multiply: {
 
   <U extends Unit.Unit>(b: Quantity<U>): (a: number) => Quantity<U>;
   <U extends Unit.Unit>(a: number, b: Quantity<U>): Quantity<U>;
+  <Q>(a: QuantityInput<Q>, b: number): Quantity<QuantityUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -194,6 +198,7 @@ export const multiply: {
 export const divide: {
   <U extends Unit.Unit>(b: number): (a: Quantity<U>) => Quantity<U>;
   <U extends Unit.Unit>(a: Quantity<U>, b: number): Quantity<U>;
+  <Q>(a: QuantityInput<Q>, b: number): Quantity<QuantityUnit<Q>>;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: number): Quantity<Unit.Unit> =>
@@ -201,8 +206,11 @@ export const divide: {
 );
 
 export const sum: {
+  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<NoInfer<U>>): Quantity<U>;
   <U extends Unit.Unit>(b: Quantity<U>): (a: Quantity<U>) => Quantity<U>;
-  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<U>): Quantity<U>;
+  <Q>(
+    b: QuantityInput<Q>,
+  ): [Q] extends [Quantity<infer U>] ? (a: Quantity<U>) => Quantity<U> : never;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -210,8 +218,11 @@ export const sum: {
 );
 
 export const subtract: {
+  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<NoInfer<U>>): Quantity<U>;
   <U extends Unit.Unit>(b: Quantity<U>): (a: Quantity<U>) => Quantity<U>;
-  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<U>): Quantity<U>;
+  <Q>(
+    b: QuantityInput<Q>,
+  ): [Q] extends [Quantity<infer U>] ? (a: Quantity<U>) => Quantity<U> : never;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -246,6 +257,10 @@ export const times: {
     a: Quantity<U1>,
     b: Quantity<U2>,
   ): Quantity<Unit.Product<U1, U2>>;
+  <Q>(
+    a: QuantityInput<Q>,
+    factor: Quantity<"Unitless">,
+  ): Quantity<QuantityUnit<Q>>;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -399,6 +414,10 @@ export const over: {
     product: Quantity<Unit.Product<U1, U2>>,
     b: Quantity<U2>,
   ): Quantity<U1>;
+  <Q>(
+    a: QuantityInput<Q>,
+    factor: Quantity<"Unitless">,
+  ): Quantity<QuantityUnit<Q>>;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -432,6 +451,10 @@ export const over_: {
     product: Quantity<Unit.Product<U1, U2>>,
     b: Quantity<U1>,
   ): Quantity<U2>;
+  <Q>(
+    a: QuantityInput<Q>,
+    factor: Quantity<"Unitless">,
+  ): Quantity<QuantityUnit<Q>>;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -515,8 +538,11 @@ export const isGreaterThanOrEqualTo: {
 
 /** Propagates NaN: if either argument is NaN, the NaN quantity is returned. */
 export const min: {
+  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<NoInfer<U>>): Quantity<U>;
   <U extends Unit.Unit>(b: Quantity<U>): (a: Quantity<U>) => Quantity<U>;
-  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<U>): Quantity<U>;
+  <Q>(
+    b: QuantityInput<Q>,
+  ): [Q] extends [Quantity<infer U>] ? (a: Quantity<U>) => Quantity<U> : never;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>
@@ -531,8 +557,11 @@ export const min: {
 
 /** Propagates NaN: if either argument is NaN, the NaN quantity is returned. */
 export const max: {
+  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<NoInfer<U>>): Quantity<U>;
   <U extends Unit.Unit>(b: Quantity<U>): (a: Quantity<U>) => Quantity<U>;
-  <U extends Unit.Unit>(a: Quantity<U>, b: Quantity<U>): Quantity<U>;
+  <Q>(
+    b: QuantityInput<Q>,
+  ): [Q] extends [Quantity<infer U>] ? (a: Quantity<U>) => Quantity<U> : never;
 } = Function.dual(
   2,
   (a: Quantity<Unit.Unit>, b: Quantity<Unit.Unit>): Quantity<Unit.Unit> =>

--- a/src/QuantityExact.ts
+++ b/src/QuantityExact.ts
@@ -84,6 +84,9 @@ export interface QuantityExact<U extends Unit.Unit>
   readonly value: Rational.Rational;
 }
 
+type QuantityExactUnit<Q> = [Q] extends [QuantityExact<infer U>] ? U : never;
+type QuantityExactInput<Q> = Q & QuantityExact<Unit.Unit>;
+
 const isQuantityExact = (u: unknown): u is QuantityExact<Unit.Unit> =>
   Predicate.hasProperty(u, TypeId);
 
@@ -175,6 +178,10 @@ export const multiply: {
     a: Rational.Rational,
     b: QuantityExact<U>,
   ): QuantityExact<U>;
+  <Q>(
+    a: QuantityExactInput<Q>,
+    b: Rational.Rational,
+  ): QuantityExact<QuantityExactUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -216,6 +223,10 @@ export const divideUnsafe: {
     a: QuantityExact<U>,
     b: Rational.Rational,
   ): QuantityExact<U>;
+  <Q>(
+    a: QuantityExactInput<Q>,
+    b: Rational.Rational,
+  ): QuantityExact<QuantityExactUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -227,12 +238,17 @@ export const divideUnsafe: {
 
 export const sum: {
   <U extends Unit.Unit>(
+    a: QuantityExact<U>,
+    b: QuantityExact<NoInfer<U>>,
+  ): QuantityExact<U>;
+  <U extends Unit.Unit>(
     b: QuantityExact<U>,
   ): (a: QuantityExact<U>) => QuantityExact<U>;
-  <U extends Unit.Unit>(
-    a: QuantityExact<U>,
-    b: QuantityExact<U>,
-  ): QuantityExact<U>;
+  <Q>(
+    b: QuantityExactInput<Q>,
+  ): [Q] extends [QuantityExact<infer U>]
+    ? (a: QuantityExact<U>) => QuantityExact<U>
+    : never;
 } = Function.dual(
   2,
   (
@@ -243,12 +259,17 @@ export const sum: {
 
 export const subtract: {
   <U extends Unit.Unit>(
+    a: QuantityExact<U>,
+    b: QuantityExact<NoInfer<U>>,
+  ): QuantityExact<U>;
+  <U extends Unit.Unit>(
     b: QuantityExact<U>,
   ): (a: QuantityExact<U>) => QuantityExact<U>;
-  <U extends Unit.Unit>(
-    a: QuantityExact<U>,
-    b: QuantityExact<U>,
-  ): QuantityExact<U>;
+  <Q>(
+    b: QuantityExactInput<Q>,
+  ): [Q] extends [QuantityExact<infer U>]
+    ? (a: QuantityExact<U>) => QuantityExact<U>
+    : never;
 } = Function.dual(
   2,
   (
@@ -287,6 +308,10 @@ export const times: {
     a: QuantityExact<U1>,
     b: QuantityExact<U2>,
   ): QuantityExact<Unit.Product<U1, U2>>;
+  <Q>(
+    a: QuantityExactInput<Q>,
+    factor: QuantityExact<"Unitless">,
+  ): QuantityExact<QuantityExactUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -529,6 +554,10 @@ export const overUnsafe: {
     product: QuantityExact<Unit.Product<U1, U2>>,
     b: QuantityExact<U2>,
   ): QuantityExact<U1>;
+  <Q>(
+    a: QuantityExactInput<Q>,
+    factor: QuantityExact<"Unitless">,
+  ): QuantityExact<QuantityExactUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -597,6 +626,10 @@ export const over_Unsafe: {
     product: QuantityExact<Unit.Product<U1, U2>>,
     b: QuantityExact<U1>,
   ): QuantityExact<U2>;
+  <Q>(
+    a: QuantityExactInput<Q>,
+    factor: QuantityExact<"Unitless">,
+  ): QuantityExact<QuantityExactUnit<Q>>;
 } = Function.dual(
   2,
   (
@@ -706,12 +739,17 @@ export const isGreaterThanOrEqualTo: {
 
 export const min: {
   <U extends Unit.Unit>(
+    a: QuantityExact<U>,
+    b: QuantityExact<NoInfer<U>>,
+  ): QuantityExact<U>;
+  <U extends Unit.Unit>(
     b: QuantityExact<U>,
   ): (a: QuantityExact<U>) => QuantityExact<U>;
-  <U extends Unit.Unit>(
-    a: QuantityExact<U>,
-    b: QuantityExact<U>,
-  ): QuantityExact<U>;
+  <Q>(
+    b: QuantityExactInput<Q>,
+  ): [Q] extends [QuantityExact<infer U>]
+    ? (a: QuantityExact<U>) => QuantityExact<U>
+    : never;
 } = Function.dual(
   2,
   (
@@ -723,12 +761,17 @@ export const min: {
 
 export const max: {
   <U extends Unit.Unit>(
+    a: QuantityExact<U>,
+    b: QuantityExact<NoInfer<U>>,
+  ): QuantityExact<U>;
+  <U extends Unit.Unit>(
     b: QuantityExact<U>,
   ): (a: QuantityExact<U>) => QuantityExact<U>;
-  <U extends Unit.Unit>(
-    a: QuantityExact<U>,
-    b: QuantityExact<U>,
-  ): QuantityExact<U>;
+  <Q>(
+    b: QuantityExactInput<Q>,
+  ): [Q] extends [QuantityExact<infer U>]
+    ? (a: QuantityExact<U>) => QuantityExact<U>
+    : never;
 } = Function.dual(
   2,
   (

--- a/test/Quantity.test.ts
+++ b/test/Quantity.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest";
+import { describe, expectTypeOf, it } from "@effect/vitest";
 import {
   assertEquals,
   assertFalse,
@@ -19,6 +19,74 @@ import * as Quantity from "../src/Quantity.ts";
 import * as Unit from "../src/Unit.ts";
 
 const nonZeroDouble = double.filter((n) => n !== 0);
+const CustomRate = Unit.rate(Unit.custom("USD"), Unit.custom("Count"));
+type CustomRate = Quantity.Quantity<typeof CustomRate>;
+const customRate = (value: number): CustomRate =>
+  Quantity.make(CustomRate, value);
+
+describe("point-free reducers", () => {
+  it("preserves accumulator units for same-unit operations", () => {
+    const rates = [customRate(1), customRate(2)];
+
+    const zero = customRate(0);
+    const total = Array.reduce(rates, zero, Quantity.sum);
+    const difference = Array.reduce(rates, zero, Quantity.subtract);
+    const minimum = Array.reduce(rates, zero, Quantity.min);
+    const maximum = Array.reduce(rates, zero, Quantity.max);
+
+    expectTypeOf(total).toEqualTypeOf<CustomRate>();
+    expectTypeOf(difference).toEqualTypeOf<CustomRate>();
+    expectTypeOf(minimum).toEqualTypeOf<CustomRate>();
+    expectTypeOf(maximum).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves accumulator units for scalar operations", () => {
+    const scalars = [2, 3];
+    const initial = customRate(1);
+
+    const product = Array.reduce(scalars, initial, Quantity.multiply);
+    const quotient = Array.reduce(scalars, initial, Quantity.divide);
+
+    expectTypeOf(product).toEqualTypeOf<CustomRate>();
+    expectTypeOf(quotient).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves accumulator units for dimensionless operations", () => {
+    const factors = [Dimensionless.fraction(2), Dimensionless.fraction(3)];
+    const initial = customRate(1);
+
+    const product = Array.reduce(factors, initial, Quantity.times);
+    const quotient = Array.reduce(factors, initial, Quantity.over);
+    const flippedQuotient = Array.reduce(factors, initial, Quantity.over_);
+
+    expectTypeOf(product).toEqualTypeOf<CustomRate>();
+    expectTypeOf(quotient).toEqualTypeOf<CustomRate>();
+    expectTypeOf(flippedQuotient).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves explicit unit arguments for data-last calls", () => {
+    const addOne = Quantity.sum<Length.Meters>(Length.meters(1));
+
+    expectTypeOf(addOne).toEqualTypeOf<
+      (a: Quantity.Quantity<Length.Meters>) => Quantity.Quantity<Length.Meters>
+    >();
+  });
+
+  it("rejects incomplete quantities and mixed units", () => {
+    const brandedOnly: { readonly [Quantity.TypeId]: Quantity.TypeId } = {
+      [Quantity.TypeId]: Quantity.TypeId,
+    };
+
+    if (globalThis.Boolean(false)) {
+      // @ts-expect-error A TypeId without the Quantity fields is not a quantity.
+      Quantity.multiply(brandedOnly, 2);
+      // @ts-expect-error The data-last overload also requires a complete quantity.
+      Quantity.sum(brandedOnly);
+      // @ts-expect-error Same-unit operations cannot combine different units.
+      Quantity.sum(Length.meters(1), Mass.kilograms(1));
+    }
+  });
+});
 
 describe("multiply", () => {
   const baseQuantities = [

--- a/test/QuantityExact.test.ts
+++ b/test/QuantityExact.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from "@effect/vitest";
+import { describe, expectTypeOf, it } from "@effect/vitest";
 import {
   assertEquals,
   assertFalse,
@@ -25,8 +25,86 @@ import * as Unit from "../src/Unit.ts";
 const meters = (r: Rational.Rational) => QuantityExact.make("Meters", r);
 const seconds = (r: Rational.Rational) => QuantityExact.make("Seconds", r);
 const kilograms = (r: Rational.Rational) => QuantityExact.make("Kilograms", r);
+const CustomRate = Unit.rate(Unit.custom("USD"), Unit.custom("Count"));
+type CustomRate = QuantityExact.QuantityExact<typeof CustomRate>;
+const customRate = (value: Rational.Rational): CustomRate =>
+  QuantityExact.make(CustomRate, value);
 
 describe("arithmetic", () => {
+  it("preserves accumulator units for point-free same-unit reducers", () => {
+    const rates = [
+      customRate(Rational.one),
+      customRate(Rational.makeUnsafe(2n)),
+    ];
+
+    const zero = customRate(Rational.zero);
+    const total = Array.reduce(rates, zero, QuantityExact.sum);
+    const difference = Array.reduce(rates, zero, QuantityExact.subtract);
+    const minimum = Array.reduce(rates, zero, QuantityExact.min);
+    const maximum = Array.reduce(rates, zero, QuantityExact.max);
+
+    expectTypeOf(total).toEqualTypeOf<CustomRate>();
+    expectTypeOf(difference).toEqualTypeOf<CustomRate>();
+    expectTypeOf(minimum).toEqualTypeOf<CustomRate>();
+    expectTypeOf(maximum).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves accumulator units for point-free scalar reducers", () => {
+    const scalars = [Rational.makeUnsafe(2n), Rational.makeUnsafe(3n)];
+    const initial = customRate(Rational.one);
+
+    const product = Array.reduce(scalars, initial, QuantityExact.multiply);
+    const quotient = Array.reduce(scalars, initial, QuantityExact.divideUnsafe);
+
+    expectTypeOf(product).toEqualTypeOf<CustomRate>();
+    expectTypeOf(quotient).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves accumulator units for point-free dimensionless reducers", () => {
+    const factors = [
+      DimensionlessExact.fraction(Rational.makeUnsafe(2n)),
+      DimensionlessExact.fraction(Rational.makeUnsafe(3n)),
+    ];
+    const initial = customRate(Rational.one);
+
+    const product = Array.reduce(factors, initial, QuantityExact.times);
+    const quotient = Array.reduce(factors, initial, QuantityExact.overUnsafe);
+    const flippedQuotient = Array.reduce(
+      factors,
+      initial,
+      QuantityExact.over_Unsafe,
+    );
+
+    expectTypeOf(product).toEqualTypeOf<CustomRate>();
+    expectTypeOf(quotient).toEqualTypeOf<CustomRate>();
+    expectTypeOf(flippedQuotient).toEqualTypeOf<CustomRate>();
+  });
+
+  it("preserves explicit unit arguments for data-last sum calls", () => {
+    const addOne = QuantityExact.sum<"Meters">(meters(Rational.one));
+
+    expectTypeOf(addOne).toEqualTypeOf<
+      (
+        a: QuantityExact.QuantityExact<"Meters">,
+      ) => QuantityExact.QuantityExact<"Meters">
+    >();
+  });
+
+  it("rejects incomplete quantities and mixed units", () => {
+    const brandedOnly: {
+      readonly [QuantityExact.TypeId]: QuantityExact.TypeId;
+    } = { [QuantityExact.TypeId]: QuantityExact.TypeId };
+
+    if (globalThis.Boolean(false)) {
+      // @ts-expect-error A TypeId without the QuantityExact fields is not a quantity.
+      QuantityExact.multiply(brandedOnly, Rational.one);
+      // @ts-expect-error The data-last overload also requires a complete quantity.
+      QuantityExact.sum(brandedOnly);
+      // @ts-expect-error Same-unit operations cannot combine different units.
+      QuantityExact.sum(meters(Rational.one), seconds(Rational.one));
+    }
+  });
+
   it("sum and subtract are exact inverses", () => {
     FastCheck.assert(
       FastCheck.property(rational, rational, (a, b) => {


### PR DESCRIPTION
## Summary

- preserve concrete custom and composite units when compatible `Quantity` and `QuantityExact` operations are passed directly to `Array.reduce`
- apply the inference fix to same-unit, scalar, and dimensionless structural counterparts
- retain data-last explicit generic calls while rejecting mixed units and incomplete TypeId-branded objects
- add a patch changeset

## Verification

- `pnpm test` (1,167 tests; no type errors)
- `pnpm typecheck`
- `pnpm build`
- `pnpm lint`
- `pnpm format:check`
- `pnpm circular`

Closes #25