### PR TITLE
Configure Amp orb lifecycle

### DIFF
--- a/.agents/resume
+++ b/.agents/resume
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+export PATH="$HOME/.local/share/effect-units/node-22/bin:$PATH"
+
+cd "$repo_root"
+
+[[ "$(node -p 'process.versions.node.split(".")[0]')" == 22 ]]
+[[ "$(pnpm --version)" == 11.10.0 ]]
+[[ -d node_modules ]]
+
+printf 'Orb ready: Node %s, pnpm %s\n' "$(node --version)" "$(pnpm --version)"

--- a/.agents/resume
+++ b/.agents/resume
@@ -8,6 +8,6 @@ cd "$repo_root"
 
 [[ "$(node -p 'process.versions.node.split(".")[0]')" == 22 ]]
 [[ "$(pnpm --version)" == 11.10.0 ]]
-[[ -d node_modules ]]
+cmp -s pnpm-lock.yaml node_modules/.pnpm/lock.yaml
 
 printf 'Orb ready: Node %s, pnpm %s\n' "$(node --version)" "$(pnpm --version)"

--- a/.agents/setup
+++ b/.agents/setup
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+node_root="$HOME/.local/share/effect-units/node-22"
+profile_marker="# effect-units orb Node.js"
+
+step() {
+  local label="$1"
+  shift
+  local started=$SECONDS
+  printf '==> %s\n' "$label"
+  "$@"
+  printf '    completed in %ss\n' "$((SECONDS - started))"
+}
+
+install_system_dependencies() {
+  local packages=()
+  command -v curl >/dev/null 2>&1 || packages+=(curl ca-certificates)
+  command -v tar >/dev/null 2>&1 || packages+=(tar)
+  command -v sha256sum >/dev/null 2>&1 || packages+=(coreutils)
+
+  if ((${#packages[@]} == 0)); then
+    return
+  fi
+
+  local apt=(apt-get)
+  if ((EUID != 0)); then
+    apt=(sudo apt-get)
+  fi
+  "${apt[@]}" update
+  "${apt[@]}" install -y "${packages[@]}"
+}
+
+install_node() {
+  if [[ -x "$node_root/bin/node" ]] &&
+    [[ "$($node_root/bin/node -p 'process.versions.node.split(".")[0]')" == 22 ]]; then
+    return
+  fi
+
+  local architecture
+  case "$(uname -m)" in
+    x86_64) architecture=x64 ;;
+    aarch64 | arm64) architecture=arm64 ;;
+    *)
+      printf 'Unsupported architecture: %s\n' "$(uname -m)" >&2
+      return 1
+      ;;
+  esac
+
+  local base_url="https://nodejs.org/dist/latest-v22.x"
+  local checksums filename checksum archive extract_dir
+  checksums="$(curl -fsSL "$base_url/SHASUMS256.txt")"
+  filename="$(awk -v arch="$architecture" '$2 ~ ("^node-v[0-9.]+-linux-" arch "\\.tar\\.gz$") { print $2 }' <<<"$checksums")"
+  if [[ -z "$filename" ]]; then
+    printf 'Could not find the latest Node 22 archive for linux-%s\n' "$architecture" >&2
+    return 1
+  fi
+  checksum="$(awk -v file="$filename" '$2 == file { print $1 }' <<<"$checksums")"
+
+  archive="$(mktemp)"
+  extract_dir="$(mktemp -d)"
+  trap 'rm -f "${archive:-}"; rm -rf "${extract_dir:-}"' RETURN
+  curl -fsSL "$base_url/$filename" -o "$archive"
+  printf '%s  %s\n' "$checksum" "$archive" | sha256sum --check --status
+  tar -xzf "$archive" -C "$extract_dir" --strip-components=1
+  rm -rf "$node_root"
+  mkdir -p "$(dirname "$node_root")"
+  mv "$extract_dir" "$node_root"
+  rm -f "$archive"
+  trap - RETURN
+}
+
+configure_login_shell() {
+  touch "$HOME/.bash_profile"
+  if ! grep -Fqx "$profile_marker" "$HOME/.bash_profile"; then
+    cat >>"$HOME/.bash_profile" <<EOF
+
+$profile_marker
+export PATH="$node_root/bin:\$PATH"
+EOF
+  fi
+}
+
+install_dependencies() {
+  cd "$repo_root"
+  corepack enable
+  corepack install --global pnpm@11.10.0
+  pnpm install --frozen-lockfile
+}
+
+step "Checking system dependencies" install_system_dependencies
+step "Installing Node.js 22" install_node
+export PATH="$node_root/bin:$PATH"
+step "Configuring login shells" configure_login_shell
+step "Installing project dependencies" install_dependencies
+
+printf 'Setup complete: Node %s, pnpm %s\n' "$(node --version)" "$(pnpm --version)"

--- a/.agents/setup
+++ b/.agents/setup
@@ -49,7 +49,7 @@ install_node() {
   esac
 
   local base_url="https://nodejs.org/dist/latest-v22.x"
-  local checksums filename checksum archive extract_dir
+  local checksums filename checksum
   checksums="$(curl -fsSL "$base_url/SHASUMS256.txt")"
   filename="$(awk -v arch="$architecture" '$2 ~ ("^node-v[0-9.]+-linux-" arch "\\.tar\\.gz$") { print $2 }' <<<"$checksums")"
   if [[ -z "$filename" ]]; then
@@ -58,17 +58,18 @@ install_node() {
   fi
   checksum="$(awk -v file="$filename" '$2 == file { print $1 }' <<<"$checksums")"
 
-  archive="$(mktemp)"
-  extract_dir="$(mktemp -d)"
-  trap 'rm -f "${archive:-}"; rm -rf "${extract_dir:-}"' RETURN
-  curl -fsSL "$base_url/$filename" -o "$archive"
-  printf '%s  %s\n' "$checksum" "$archive" | sha256sum --check --status
-  tar -xzf "$archive" -C "$extract_dir" --strip-components=1
-  rm -rf "$node_root"
-  mkdir -p "$(dirname "$node_root")"
-  mv "$extract_dir" "$node_root"
-  rm -f "$archive"
-  trap - RETURN
+  (
+    local archive extract_dir
+    archive="$(mktemp)"
+    extract_dir="$(mktemp -d)"
+    trap 'rm -f "$archive"; rm -rf "$extract_dir"' EXIT
+    curl -fsSL "$base_url/$filename" -o "$archive"
+    printf '%s  %s\n' "$checksum" "$archive" | sha256sum --check --status
+    tar -xzf "$archive" -C "$extract_dir" --strip-components=1
+    rm -rf "$node_root"
+    mkdir -p "$(dirname "$node_root")"
+    mv "$extract_dir" "$node_root"
+  )
 }
 
 configure_login_shell() {

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ dist/
 coverage/
 *.tsbuildinfo
 tsconfig.vitest-temp.json
+.amp/portals/*
 .DS_Store


### PR DESCRIPTION
## Summary

- install Node.js 22 and the package-pinned pnpm version in fresh Amp orbs
- install dependencies idempotently and expose the toolchain to future login shells
- add a fast resume-time environment check
- ignore generated Amp portal metadata

## Verification

- cold setup completed in 27 seconds
- warm setup completed in 1.2 seconds
- resume completed in 1.0 second
- `pnpm typecheck` passed in a clean non-interactive login shell
- both lifecycle scripts are committed executable (mode 100755)