### PR TITLE
Add relative-tolerance quantity comparison

### DIFF
--- a/.changeset/fuzzy-measurements-compare.md
+++ b/.changeset/fuzzy-measurements-compare.md
@@ -1,0 +1,5 @@
+---
+"effect-units": minor
+---
+
+Add `Quantity.equalsWithinRelative` for comparing measurements with a unitless relative tolerance.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Equality is two-tier:
 
 - `Equal.equals`/`Quantity.equals` is **exact**—identical value (NaN equals itself; -0 is normalized to 0) and structurally equal units. This is identity, suitable for `HashMap` keys, not for comparing computed measurements.
 - `Quantity.equalsWithin(a, b, tolerance)` is the domain-level comparison—the tolerance is itself a quantity in the same units, e.g. `Quantity.equalsWithin(a, b, Length.millimeters(1))`. Identical values—including two equal infinities—are equal within any tolerance; NaN is never equal to anything.
+- `Quantity.equalsWithinRelative(a, b, tolerance)` compares two measurements against a unitless relative tolerance, e.g. `Quantity.equalsWithinRelative(a, b, Dimensionless.percent(1))`. It divides their absolute difference by their mean magnitude, with two zeroes considered equal. Identical infinities are equal; NaN and unequal infinities are not.
 
 The ordering predicates (`isLessThan`, `isGreaterThan`, …) follow IEEE NaN semantics: any comparison involving NaN is false. `min` and `max` propagate NaN deterministically, like `Math.min`/`Math.max`.
 

--- a/src/Quantity.ts
+++ b/src/Quantity.ts
@@ -173,6 +173,42 @@ export const equalsWithin: {
     Math.abs(a.value - b.value) <= Math.abs(tolerance.value),
 );
 
+/**
+ * Relative-tolerance equality: whether the absolute difference between `a`
+ * and `b`, divided by their mean magnitude, is no more than `tolerance`.
+ * This symmetric comparison is useful for two measurements of the same
+ * quantity. Two zeroes are equal despite having no relative magnitude;
+ * identical infinities are equal, while NaN and unequal infinities are not.
+ */
+export const equalsWithinRelative: {
+  <U extends Unit.Unit>(
+    b: Quantity<U>,
+    tolerance: Quantity<"Unitless">,
+  ): (a: Quantity<U>) => boolean;
+  <U extends Unit.Unit>(
+    a: Quantity<U>,
+    b: Quantity<NoInfer<U>>,
+    tolerance: Quantity<"Unitless">,
+  ): boolean;
+} = Function.dual(
+  3,
+  (
+    a: Quantity<Unit.Unit>,
+    b: Quantity<Unit.Unit>,
+    tolerance: Quantity<"Unitless">,
+  ): boolean => {
+    if (a.value === b.value) return true;
+
+    const magnitudeA = Math.abs(a.value);
+    const magnitudeB = Math.abs(b.value);
+    const scale = Math.max(magnitudeA, magnitudeB);
+    const difference = Math.abs(a.value / scale - b.value / scale);
+    const meanMagnitude = (magnitudeA / scale + magnitudeB / scale) / 2;
+
+    return difference / meanMagnitude <= Math.abs(tolerance.value);
+  },
+);
+
 export const multiply: {
   <U extends Unit.Unit>(b: number): (a: Quantity<U>) => Quantity<U>;
   <U extends Unit.Unit>(a: Quantity<U>, b: number): Quantity<U>;

--- a/test/Quantity.test.ts
+++ b/test/Quantity.test.ts
@@ -632,6 +632,126 @@ describe("equalsWithin", () => {
   });
 });
 
+describe("equalsWithinRelative", () => {
+  it("compares the difference against the mean magnitude", () => {
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.meters(100),
+        Length.meters(101),
+        Dimensionless.percent(1),
+      ),
+    );
+    assertFalse(
+      Quantity.equalsWithinRelative(
+        Length.meters(100),
+        Length.meters(102),
+        Dimensionless.percent(1),
+      ),
+    );
+  });
+
+  it("is symmetric and supports data-last calls", () => {
+    const isWithinOnePercent = Quantity.equalsWithinRelative(
+      Length.meters(101),
+      Dimensionless.percent(1),
+    );
+
+    expectTypeOf(isWithinOnePercent).toEqualTypeOf<
+      (a: Quantity.Quantity<Length.Meters>) => boolean
+    >();
+    assertTrue(isWithinOnePercent(Length.meters(100)));
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.meters(101),
+        Length.meters(100),
+        Dimensionless.percent(1),
+      ),
+    );
+
+    if (globalThis.Boolean(false)) {
+      Quantity.equalsWithinRelative(
+        Length.meters(100),
+        Length.meters(101),
+        // @ts-expect-error Relative tolerance must be unitless.
+        Length.meters(1),
+      );
+      Quantity.equalsWithinRelative(
+        Length.meters(100),
+        // @ts-expect-error The compared quantities must have the same unit.
+        Mass.kilograms(100),
+        Dimensionless.percent(1),
+      );
+    }
+  });
+
+  it("handles zero magnitudes", () => {
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.zero,
+        Length.zero,
+        Dimensionless.fraction(0),
+      ),
+    );
+    assertFalse(
+      Quantity.equalsWithinRelative(
+        Length.zero,
+        Length.meters(1),
+        Dimensionless.fraction(1.99),
+      ),
+    );
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.zero,
+        Length.meters(1),
+        Dimensionless.fraction(2),
+      ),
+    );
+  });
+
+  it("avoids overflow and underflow at finite extremes", () => {
+    const tolerance = Dimensionless.fraction(2);
+
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.zero,
+        Length.meters(Number.MIN_VALUE),
+        tolerance,
+      ),
+    );
+    assertTrue(
+      Quantity.equalsWithinRelative(
+        Length.meters(Number.MAX_VALUE),
+        Length.meters(-Number.MAX_VALUE),
+        tolerance,
+      ),
+    );
+  });
+
+  it("is false for NaN and unequal infinities", () => {
+    const infinite = Length.meters(Infinity);
+    const tolerance = Dimensionless.percent(1);
+
+    assertFalse(
+      Quantity.equalsWithinRelative(
+        Quantity.make("Meters", NaN),
+        Length.meters(1),
+        tolerance,
+      ),
+    );
+    assertTrue(Quantity.equalsWithinRelative(infinite, infinite, tolerance));
+    assertFalse(
+      Quantity.equalsWithinRelative(
+        infinite,
+        Length.meters(-Infinity),
+        tolerance,
+      ),
+    );
+    assertFalse(
+      Quantity.equalsWithinRelative(infinite, Length.meters(1), tolerance),
+    );
+  });
+});
+
 describe("comparison", () => {
   it("orders quantities", () => {
     const short = Length.meters(1);


### PR DESCRIPTION
## Summary

- add a symmetric `Quantity.equalsWithinRelative` comparison with a unitless tolerance
- normalize the calculation to avoid overflow and underflow across finite doubles
- document and test zero, NaN, infinity, data-last, and type-safety behavior

Closes #24

## Verification

- `pnpm test`
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm circular`