### PR TITLE
Refactor grid arbitraries to a typed functional style

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Schema.encodeSync(Schema.toCodecJson(Trip))({
 
 Reach for `XFromStruct` when you want the precise `{ unit, value }` encoded type; reach for `Schema.toCodecJson` when the quantity is part of a larger structure (its encoded type is `Json`).
 
-For property tests over values people actually enter, annotate a quantity schema with an integer-backed grid. Bounds are inclusive quantity values, and generated values remain exact multiples of `step` while shrinking. The helper is dual, so `pipe(unit, Quantity.arbitraryOnGrid(options))` works as well:
+When a property test should cover what people type into a number input—not arbitrary reals—annotate the quantity schema with an integer-backed grid. Bounds are inclusive, and generated values remain exact multiples of `step` while shrinking. Dual, so `pipe(unit, Quantity.arbitraryOnGrid(options))` works as well:
 
 ```ts
 import * as Quantity from "effect-units/Quantity";

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Schema.encodeSync(Schema.toCodecJson(Trip))({
 
 Reach for `XFromStruct` when you want the precise `{ unit, value }` encoded type; reach for `Schema.toCodecJson` when the quantity is part of a larger structure (its encoded type is `Json`).
 
-For property tests over values people actually enter, annotate a quantity schema with an integer-backed grid. Bounds are inclusive quantity values, and generated values remain exact multiples of `step` while shrinking:
+For property tests over values people actually enter, annotate a quantity schema with an integer-backed grid. Bounds are inclusive quantity values, and generated values remain exact multiples of `step` while shrinking. The helper is dual, so `pipe(unit, Quantity.arbitraryOnGrid(options))` works as well:
 
 ```ts
 import * as Quantity from "effect-units/Quantity";

--- a/src/Quantity.ts
+++ b/src/Quantity.ts
@@ -151,14 +151,8 @@ const grid = ({
     );
 
     const stepRational = Rational.fromBigDecimal(
-      yield* Result.fromOption(BigDecimal.fromNumber(positiveStep), () =>
-        gridError("step has unsupported precision"),
-      ),
+      BigDecimal.fromNumberUnsafe(positiveStep),
     );
-    if (Rational.toNumberUnsafe(stepRational) !== positiveStep) {
-      return yield* Result.fail(gridError("step has unsupported precision"));
-    }
-
     const valueAt = valueOnGrid(stepRational);
     const minimum = snapLowerIndex(
       valueAt,

--- a/src/Quantity.ts
+++ b/src/Quantity.ts
@@ -1,9 +1,11 @@
+import * as BigDecimal from "effect/BigDecimal";
 import * as Equal from "effect/Equal";
 import * as Function from "effect/Function";
 import * as Hash from "effect/Hash";
 import type * as Inspectable from "effect/Inspectable";
 import type * as Pipeable from "effect/Pipeable";
 import * as Predicate from "effect/Predicate";
+import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";
 
@@ -17,6 +19,7 @@ import {
   ValueObjectProto,
   valueEquals,
 } from "./internal/valueObject.ts";
+import * as Rational from "./Rational.ts";
 import * as Unit from "./Unit.ts";
 
 export const TypeId = Symbol.for("effect-units/Quantity");
@@ -77,13 +80,119 @@ export interface ArbitraryOnGridOptions {
   readonly max: number;
 }
 
+interface Grid {
+  readonly step: Rational.Rational;
+  readonly minimum: number;
+  readonly maximum: number;
+}
+
+const gridError = (message: string): RangeError =>
+  new RangeError(`Quantity.arbitraryOnGrid: ${message}`);
+
+const isPositiveFinite = (n: number): boolean => Number.isFinite(n) && n > 0;
+
+/**
+ * The float on the human-decimal grid at `index`: `index × step` as a
+ * rational, correctly rounded. 7 on a tenths grid is `0.7`, not
+ * `0.7000000000000001`.
+ */
+const valueOnGrid =
+  (step: Rational.Rational) =>
+  (index: number): number =>
+    Rational.toNumberUnsafe(
+      Rational.multiply(step, Rational.fromBigInt(globalThis.BigInt(index))),
+    );
+
+const snapLowerIndex = (
+  valueAt: (index: number) => number,
+  min: number,
+  candidate: number,
+): number =>
+  valueAt(candidate - 1) >= min
+    ? candidate - 1
+    : valueAt(candidate) < min
+      ? candidate + 1
+      : candidate;
+
+const snapUpperIndex = (
+  valueAt: (index: number) => number,
+  max: number,
+  candidate: number,
+): number =>
+  valueAt(candidate + 1) <= max
+    ? candidate + 1
+    : valueAt(candidate) > max
+      ? candidate - 1
+      : candidate;
+
+/**
+ * Derives the integer index range whose generated values lie in
+ * `[min, max]`. Invalid developer-written options are a defect
+ * (`RangeError`), matching {@link Unit.custom}.
+ */
+const grid = ({
+  step,
+  min,
+  max,
+}: ArbitraryOnGridOptions): Result.Result<Grid, RangeError> =>
+  Result.gen(function* () {
+    const positiveStep = yield* Result.liftPredicate(
+      step,
+      isPositiveFinite,
+      () => gridError("step must be positive"),
+    );
+    const finiteMin = yield* Result.liftPredicate(min, Number.isFinite, () =>
+      gridError("min and max must be finite and min must not exceed max"),
+    );
+    const finiteMax = yield* Result.liftPredicate(
+      max,
+      (bound) => Number.isFinite(bound) && bound >= finiteMin,
+      () => gridError("min and max must be finite and min must not exceed max"),
+    );
+
+    const stepRational = Rational.fromBigDecimal(
+      yield* Result.fromOption(BigDecimal.fromNumber(positiveStep), () =>
+        gridError("step has unsupported precision"),
+      ),
+    );
+    if (Rational.toNumberUnsafe(stepRational) !== positiveStep) {
+      return yield* Result.fail(gridError("step has unsupported precision"));
+    }
+
+    const valueAt = valueOnGrid(stepRational);
+    const minimum = snapLowerIndex(
+      valueAt,
+      finiteMin,
+      Math.ceil(finiteMin / positiveStep),
+    );
+    const maximum = snapUpperIndex(
+      valueAt,
+      finiteMax,
+      Math.floor(finiteMax / positiveStep),
+    );
+
+    if (
+      !Number.isSafeInteger(minimum) ||
+      !Number.isSafeInteger(maximum) ||
+      minimum > maximum
+    ) {
+      return yield* Result.fail(
+        gridError("bounds must contain a grid value with a safe integer index"),
+      );
+    }
+
+    return { step: stepRational, minimum, maximum };
+  });
+
 /**
  * Schema annotations for quantities constrained to a human-input grid.
  *
  * Generated values are multiples of `step` between `min` and `max`,
  * inclusive. Generation starts from integers so shrinking stays on the grid;
- * decimal steps are applied as integer ratios to avoid introducing artifacts
- * such as `0.7000000000000001` for a tenths grid.
+ * decimal steps are the exact rationals of their decimal representation, so
+ * a tenths grid yields `0.7` rather than `0.7000000000000001`. Dual, so
+ * either `arbitraryOnGrid(unit, options)` or
+ * `pipe(unit, arbitraryOnGrid(options))`.
  *
  * @example
  * ```ts
@@ -96,63 +205,30 @@ export interface ArbitraryOnGridOptions {
  * )
  * ```
  */
-export const arbitraryOnGrid = <const U extends Unit.Unit>(
-  unit: U,
-  { step, min, max }: ArbitraryOnGridOptions,
-): Schema.Annotations.Declaration<Quantity<U>> => {
-  if (!Number.isFinite(step) || step <= 0) {
-    throw new RangeError("Quantity.arbitraryOnGrid: step must be positive");
-  }
-  if (!Number.isFinite(min) || !Number.isFinite(max) || min > max) {
-    throw new RangeError(
-      "Quantity.arbitraryOnGrid: min and max must be finite and min must not exceed max",
-    );
-  }
-
-  const [coefficient = "", exponentText] = globalThis.String(step).split("e");
-  const fractionDigits = coefficient.split(".")[1]?.length ?? 0;
-  const exponent = exponentText === undefined ? 0 : Number(exponentText);
-  const scale = 10 ** Math.max(0, fractionDigits - exponent);
-  const increment = step * scale;
-
-  if (!Number.isFinite(scale) || !Number.isInteger(increment)) {
-    throw new RangeError(
-      "Quantity.arbitraryOnGrid: step has unsupported precision",
-    );
-  }
-
-  const valueAt = (index: number) => (index * increment) / scale;
-  let minimum = Math.ceil(min / step);
-  let maximum = Math.floor(max / step);
-
-  if (valueAt(minimum - 1) >= min) {
-    minimum -= 1;
-  } else if (valueAt(minimum) < min) {
-    minimum += 1;
-  }
-  if (valueAt(maximum + 1) <= max) {
-    maximum += 1;
-  } else if (valueAt(maximum) > max) {
-    maximum -= 1;
-  }
-
-  if (
-    !Number.isSafeInteger(minimum) ||
-    !Number.isSafeInteger(maximum) ||
-    minimum > maximum
-  ) {
-    throw new RangeError(
-      "Quantity.arbitraryOnGrid: bounds must contain a grid value with a safe integer index",
-    );
-  }
-
-  return {
-    toArbitrary: () => (fc) =>
-      fc
-        .integer({ min: minimum, max: maximum })
-        .map((n) => make(unit, valueAt(n))),
-  };
-};
+export const arbitraryOnGrid: {
+  <const U extends Unit.Unit>(
+    options: ArbitraryOnGridOptions,
+  ): (unit: U) => Schema.Annotations.Declaration<Quantity<U>>;
+  <const U extends Unit.Unit>(
+    unit: U,
+    options: ArbitraryOnGridOptions,
+  ): Schema.Annotations.Declaration<Quantity<U>>;
+} = Function.dual(
+  2,
+  <U extends Unit.Unit>(
+    unit: U,
+    options: ArbitraryOnGridOptions,
+  ): Schema.Annotations.Declaration<Quantity<U>> => {
+    const { step, minimum, maximum } = Result.getOrThrow(grid(options));
+    const valueAt = valueOnGrid(step);
+    return {
+      toArbitrary: () => (fc) =>
+        fc
+          .integer({ min: minimum, max: maximum })
+          .map((n) => make(unit, valueAt(n))),
+    };
+  },
+);
 
 /**
  * A quantity is a plain 64-bit float tagged with a unit tree. Arithmetic

--- a/test/Quantity.test.ts
+++ b/test/Quantity.test.ts
@@ -4,11 +4,13 @@ import {
   assertFalse,
   assertTrue,
   deepStrictEqual,
+  throws,
 } from "@effect/vitest/utils";
 import * as Array from "effect/Array";
 import * as Result from "effect/Result";
 import * as Equal from "effect/Equal";
 import * as FastCheck from "effect/testing/FastCheck";
+import * as Function from "effect/Function";
 import * as Schema from "effect/Schema";
 
 import { isCloseTo, double } from "./testUtils.ts";
@@ -480,15 +482,15 @@ describe("schema", () => {
     );
     expectTypeOf(MeasuredLength.Type).toEqualTypeOf<Length.Length>();
 
-    const samples = FastCheck.sample(Schema.toArbitrary(MeasuredLength), 100);
-
-    assertTrue(
-      samples.every(
-        ({ unit, value }) =>
-          Unit.equals(unit, Length.Meters) &&
-          value >= -0.3 &&
-          value <= 0.7 &&
-          value === Number(value.toFixed(1)),
+    FastCheck.assert(
+      FastCheck.property(
+        Schema.toArbitrary(MeasuredLength),
+        ({ unit, value }) => {
+          assertTrue(Unit.equals(unit, Length.Meters));
+          assertTrue(value >= -0.3);
+          assertTrue(value <= 0.7);
+          assertEquals(value, Number(value.toFixed(1)));
+        },
       ),
     );
 
@@ -515,6 +517,76 @@ describe("schema", () => {
     FastCheck.assert(
       FastCheck.property(Schema.toArbitrary(RoundedBoundary), ({ value }) => {
         assertEquals(value, 0.4);
+      }),
+    );
+
+    const Tenths = Length.Length.annotate(
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0.1,
+        min: 0.7,
+        max: 0.7,
+      }),
+    );
+    FastCheck.assert(
+      FastCheck.property(Schema.toArbitrary(Tenths), ({ value }) => {
+        assertEquals(value, 0.7);
+      }),
+    );
+
+    const Piped = Length.Length.annotate(
+      Function.pipe(
+        Length.Meters,
+        Quantity.arbitraryOnGrid({
+          step: 1e-2,
+          min: 0,
+          max: 0.02,
+        }),
+      ),
+    );
+    expectTypeOf(Piped.Type).toEqualTypeOf<Length.Length>();
+    const pipedValues = FastCheck.sample(Schema.toArbitrary(Piped), 50);
+    assertTrue(
+      Array.every(
+        pipedValues,
+        ({ value }) => value === 0 || value === 0.01 || value === 0.02,
+      ),
+    );
+  });
+
+  it("rejects invalid grid options", () => {
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0,
+        min: 0,
+        max: 1,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: -0.1,
+        min: 0,
+        max: 1,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: Number.NaN,
+        min: 0,
+        max: 1,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0.1,
+        min: 1,
+        max: 0,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0.1,
+        min: 0.11,
+        max: 0.19,
       }),
     );
   });

--- a/test/Quantity.test.ts
+++ b/test/Quantity.test.ts
@@ -578,6 +578,20 @@ describe("schema", () => {
     throws(() =>
       Quantity.arbitraryOnGrid(Length.Meters, {
         step: 0.1,
+        min: Number.POSITIVE_INFINITY,
+        max: 1,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0.1,
+        min: 0,
+        max: Number.POSITIVE_INFINITY,
+      }),
+    );
+    throws(() =>
+      Quantity.arbitraryOnGrid(Length.Meters, {
+        step: 0.1,
         min: 1,
         max: 0,
       }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- rewrite `Quantity.arbitraryOnGrid` as a `Result` pipeline over exact `Rational` steps instead of mutating float indexes and parsing `String(step)`
- make the helper dual so `pipe(unit, arbitraryOnGrid(options))` infers the same unit as the data-first form
- keep generated values on the human decimal grid (`0.7`, not `0.7000000000000001`) and reject empty or invalid grids as defects
- clarify in the README that the helper is for number-input values, not arbitrary reals

## Verification

- `pnpm test` (1,171 tests; no type errors)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm circular`
- `pnpm build`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de428f9d-ecfe-4de2-b2e7-9afaf6774e25?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de428f9d-ecfe-4de2-b2e7-9afaf6774e25&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

